### PR TITLE
applies semver range to iconv-lite dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "node scripts/update.js"
   },
   "dependencies": {
-    "iconv-lite": "0.4.13"
+    "iconv-lite": "^0.4.13"
   },
   "devDependencies": {
     "eslint": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "node scripts/update.js"
   },
   "dependencies": {
-    "iconv-lite": "^0.4.13"
+    "iconv-lite": "0.4.19"
   },
   "devDependencies": {
     "eslint": "^3.8.0",


### PR DESCRIPTION
This change expands the version restriction on the `iconv-lite` dependency in `package.json` to allow for higher patch-level versions of this dependency. This will help projects that depend on both this project as well as `iconv-lite` because it will allow for the most recent patch version (at present date, [version 0.4.19](https://yarnpkg.com/en/package/iconv-lite)) to be downloaded. This is instead of enforcing that the older 0.4.13 version, [almost 2 year older than the latest version](https://github.com/ashtuchkin/iconv-lite/releases), be downloaded.

The project that I am working on uses yarn and currently has two different `iconv-lite` versions listed in its `yarn.lock` file. That's because my dependency on `whatwg-encoding` brings in `iconv-lite@0.4.13`, but other dependencies of my project have a downstream dependency on a caret-range of `iconv-lite`, resolving to the latest version of `0.4.19`. By merging in this PR and releasing it as a patch-level release, I can now consolidate this duplicated dependency on my project.

It's very possible that this change is being proposed with little/no context as to why this dependency was chosen to be an exact version in the first. My apologies if my analysis and reasonings for pursuing this upgrade are insufficient. Feel free to close this PR in that case.