### PR TITLE
Update iconv-lite to fix deprecation warning for Node v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "node scripts/update.js"
   },
   "dependencies": {
-    "iconv-lite": "0.4.19"
+    "iconv-lite": "0.4.23"
   },
   "devDependencies": {
     "eslint": "^3.8.0",


### PR DESCRIPTION
```
(node:299) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
    at showFlaggedDeprecation (buffer.js:159:11)
    at new Buffer (buffer.js:174:3)
    at module.exports (/opt/atlassian/pipelines/agent/build/node_modules/whatwg-encoding/node_modules/iconv-lite/lib/extend-node.js:11:46)
    at Object.<anonymous> (/opt/atlassian/pipelines/agent/build/node_modules/whatwg-encoding/node_modules/iconv-lite/lib/index.js:143:29)
```
See: https://github.com/ashtuchkin/iconv-lite/blob/master/Changelog.md#0423--2018-05-07