### PR TITLE
Bump iconv-lite to 0.4.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -718,9 +718,9 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": "2.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "node scripts/update.js"
   },
   "dependencies": {
-    "iconv-lite": "0.4.23"
+    "iconv-lite": "0.4.24"
   },
   "devDependencies": {
     "eslint": "^5.3.0",


### PR DESCRIPTION
Some minor fixes and a new encoding (MIK): https://github.com/ashtuchkin/iconv-lite/compare/v0.4.23...v0.4.24

Biggest gain however is that it deduplicates with other modules using `iconv-lite`.