### PR TITLE
feat: switch from iconv-lite to exodus/bytes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18
+          # Explicitly test minimum Node.js versions. Keep in sync with package.json.
+          - 20.19.0
           - 20
-          - latest
+          - 22.12.0
+          - 22
+          - 24.0.0
+          - lts/*   # currently 24
+          - latest  # currently 25
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Decode According to the WHATWG Encoding Standard
 
-This package provides a thin layer on top of [iconv-lite](https://github.com/ashtuchkin/iconv-lite) which makes it expose some of the same primitives as the [Encoding Standard](https://encoding.spec.whatwg.org/).
+This package provides a thin layer on top of [@exodus/bytes](https://github.com/ExodusOSS/bytes) which makes it expose some of the same primitives as the [Encoding Standard](https://encoding.spec.whatwg.org/).
 
 ```js
 const whatwgEncoding = require("whatwg-encoding");
@@ -13,8 +13,8 @@ console.assert(whatwgEncoding.isSupported("IBM866") === true);
 // Not supported by the Encoding Standard
 console.assert(whatwgEncoding.isSupported("UTF-32") === false);
 
-// In the Encoding Standard, but this package can't decode it
-console.assert(whatwgEncoding.isSupported("x-mac-cyrillic") === false);
+// In the Encoding Standard, and this package can decode it
+console.assert(whatwgEncoding.isSupported("x-mac-cyrillic") === true);
 
 console.assert(whatwgEncoding.getBOMEncoding(new Uint8Array([0xFE, 0xFF])) === "UTF-16BE");
 console.assert(whatwgEncoding.getBOMEncoding(new Uint8Array([0x48, 0x69])) === null);
@@ -26,20 +26,8 @@ console.assert(whatwgEncoding.decode(new Uint8Array([0x48, 0x69]), "UTF-8") === 
 
 - `decode(uint8Array, fallbackEncodingName)`: performs the [decode](https://encoding.spec.whatwg.org/#decode) algorithm (in which any BOM will override the passed fallback encoding), and returns the resulting string
 - `labelToName(label)`: performs the [get an encoding](https://encoding.spec.whatwg.org/#concept-encoding-get) algorithm and returns the resulting encoding's name, or `null` for failure
-- `isSupported(name)`: returns whether the encoding is one of [the encodings](https://encoding.spec.whatwg.org/#names-and-labels) of the Encoding Standard, _and_ is an encoding that this package can decode (via iconv-lite)
+- `isSupported(name)`: returns whether the encoding is one of [the encodings](https://encoding.spec.whatwg.org/#names-and-labels) of the Encoding Standard, _and_ is an encoding that this package can decode
 - `getBOMEncoding(uint8Array)`: sniffs the first 2–3 bytes of the supplied `Uint8Array`, returning one of the encoding names `"UTF-8"`, `"UTF-16LE"`, or `"UTF-16BE"` if the appropriate BOM is present, or `null` if no BOM is present
-
-## Unsupported encodings
-
-Since we rely on iconv-lite, we are limited to support only the encodings that they support. Currently we are missing support for:
-
-- ISO-2022-JP
-- ISO-8859-8-I
-- replacement
-- x-mac-cyrillic
-- x-user-defined
-
-Passing these encoding names will return `false` when calling `isSupported`, and passing any of the possible labels for these encodings to `labelToName` will return `null`.
 
 ## Credits
 

--- a/lib/whatwg-encoding.js
+++ b/lib/whatwg-encoding.js
@@ -1,58 +1,30 @@
 "use strict";
-const iconvLite = require("iconv-lite");
 const supportedNames = require("./supported-names.json");
-const labelsToNames = require("./labels-to-names.json");
+const lib = require("@exodus/bytes/encoding.js");
 
 const supportedNamesSet = new Set(supportedNames);
+const toCased = new Map(supportedNames.map(name => [name.toLowerCase(), name]));
 
 // https://encoding.spec.whatwg.org/#concept-encoding-get
 exports.labelToName = label => {
-  label = String(label).trim().toLowerCase();
-
-  return labelsToNames[label] || null;
+  const encoding = lib.normalizeEncoding(label);
+  return (encoding && toCased.get(encoding)) || null;
 };
 
 // https://encoding.spec.whatwg.org/#decode
 exports.decode = (uint8Array, fallbackEncodingName) => {
-  let encoding = fallbackEncodingName;
+  const encoding = fallbackEncodingName;
   if (!exports.isSupported(encoding)) {
     throw new RangeError(`"${encoding}" is not a supported encoding name`);
   }
 
-  const bomEncoding = exports.getBOMEncoding(uint8Array);
-  if (bomEncoding !== null) {
-    encoding = bomEncoding;
-    // iconv-lite will strip BOMs for us, so no need to do the extra byte removal that the spec does.
-    // Note that we won't end up in the x-user-defined case when there's a bomEncoding.
-  }
-
-  if (encoding === "x-user-defined") {
-    // https://encoding.spec.whatwg.org/#x-user-defined-decoder
-    let result = "";
-    for (const byte of uint8Array) {
-      if (byte <= 0x7F) {
-        result += String.fromCodePoint(byte);
-      } else {
-        result += String.fromCodePoint(0xF780 + byte - 0x80);
-      }
-    }
-    return result;
-  }
-
-  return iconvLite.decode(uint8Array, encoding);
+  return lib.legacyHookDecode(uint8Array, encoding.toLowerCase());
 };
 
 // https://github.com/whatwg/html/issues/1910#issuecomment-254017369
 exports.getBOMEncoding = uint8Array => {
-  if (uint8Array[0] === 0xFE && uint8Array[1] === 0xFF) {
-    return "UTF-16BE";
-  } else if (uint8Array[0] === 0xFF && uint8Array[1] === 0xFE) {
-    return "UTF-16LE";
-  } else if (uint8Array[0] === 0xEF && uint8Array[1] === 0xBB && uint8Array[2] === 0xBF) {
-    return "UTF-8";
-  }
-
-  return null;
+  const encoding = lib.getBOMEncoding(uint8Array);
+  return encoding ? encoding.toUpperCase() : null;
 };
 
 exports.isSupported = name => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
-        "iconv-lite": "0.6.3"
+        "@exodus/bytes": "^1.0.0-rc.12"
       },
       "devDependencies": {
         "@domenic/eslint-config": "^4.0.0",
@@ -17,7 +17,7 @@
         "globals": "^15.8.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@domenic/eslint-config": {
@@ -141,6 +141,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PK3i2HOX1zjVw+4UYk+iNWxCTcUDmCavNqqFkb6hb7E3BCkGwkTOvfBH63+Gwkb4K8Ckn7+0D0gIa1xbymN6YQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@exodus/crypto": "^1.0.0-rc.4"
+      },
+      "peerDependenciesMeta": {
+        "@exodus/crypto": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -213,6 +230,7 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -411,6 +429,7 @@
       "integrity": "sha512-FzJ9D/0nGiCGBf8UXO/IGLTgLVzIxze1zpfA8Ton2mjLovXdAPlYDv+MQDcqj3TmrhAGYfOpz9RfR+ent0AgAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
@@ -667,18 +686,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -1034,12 +1041,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "node scripts/update.js"
   },
   "dependencies": {
-    "iconv-lite": "0.6.3"
+    "@exodus/bytes": "^1.0.0-rc.12"
   },
   "devDependencies": {
     "@domenic/eslint-config": "^4.0.0",
@@ -28,6 +28,6 @@
     "globals": "^15.8.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   }
 }

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 const fs = require("fs");
 const path = require("path");
-const iconvLite = require("iconv-lite");
+const lib = require("@exodus/bytes/encoding.js");
 
 async function main() {
   const res = await fetch("https://encoding.spec.whatwg.org/encodings.json");
@@ -11,19 +11,16 @@ async function main() {
   const supportedNames = [];
   for (const entry of body) {
     for (const encoding of entry.encodings) {
-      if (iconvLite.encodingExists(encoding.name) || encoding.name === "x-user-defined") {
-        supportedNames.push(encoding.name);
-        for (const label of encoding.labels) {
-          labelsToNames[label] = encoding.name;
-        }
+      lib.normalizeEncoding(encoding.name); // asserts support
+      supportedNames.push(encoding.name);
+      for (const label of encoding.labels) {
+        labelsToNames[label] = encoding.name;
       }
     }
   }
 
-  const labelsToNamesOutput = JSON.stringify(labelsToNames, undefined, 2);
-  fs.writeFileSync(path.resolve(__dirname, "../lib/labels-to-names.json"), labelsToNamesOutput);
-
   const supportedNamesOutput = JSON.stringify(supportedNames, undefined, 2);
+  fs.rmSync(path.resolve(__dirname, "../lib/labels-to-names.json"), { force: true });
   fs.writeFileSync(path.resolve(__dirname, "../lib/supported-names.json"), supportedNamesOutput);
 }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -46,11 +46,11 @@ describe("decode", () => {
     assert.throws(() => whatwgEncoding.decode(new Uint8Array([]), "UTF-32"), RangeError);
   });
 
-  it("should throw when given an unsupported encoding name", () => {
-    assert.throws(() => whatwgEncoding.decode(new Uint8Array([]), "ISO-2022-JP"), RangeError);
-    assert.throws(() => whatwgEncoding.decode(new Uint8Array([]), "ISO-8859-8-I"), RangeError);
-    assert.throws(() => whatwgEncoding.decode(new Uint8Array([]), "replacement"), RangeError);
-    assert.throws(() => whatwgEncoding.decode(new Uint8Array([]), "x-mac-cyrillic"), RangeError);
+  it("should not throw on a supported encoding name", () => {
+    assert.strictEqual(whatwgEncoding.decode(new Uint8Array([]), "ISO-2022-JP"), "");
+    assert.strictEqual(whatwgEncoding.decode(new Uint8Array([]), "ISO-8859-8-I"), "");
+    assert.strictEqual(whatwgEncoding.decode(new Uint8Array([]), "replacement"), "");
+    assert.strictEqual(whatwgEncoding.decode(new Uint8Array([]), "x-mac-cyrillic"), "");
   });
 
   it("should throw when given an encoding label that is not a name", () => {
@@ -96,26 +96,27 @@ describe("labelToName", () => {
   it("should return null for invalid encoding labels", () => {
     assert.strictEqual(whatwgEncoding.labelToName("AS\u0009CII"), null);
     assert.strictEqual(whatwgEncoding.labelToName("asdf"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("replacement"), null);
     assert.strictEqual(whatwgEncoding.labelToName("UTF-32"), null);
   });
 
-  it("should return null for unsupported encoding labels", () => {
-    assert.strictEqual(whatwgEncoding.labelToName("ISO-2022-JP"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("csiso2022jp"), null);
+  it("should return names for supported encoding labels", () => {
+    assert.strictEqual(whatwgEncoding.labelToName("replacement"), "replacement");
 
-    assert.strictEqual(whatwgEncoding.labelToName("ISO-8859-8-I"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("csiso88598i"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("logical"), null);
+    assert.strictEqual(whatwgEncoding.labelToName("ISO-2022-JP"), "ISO-2022-JP");
+    assert.strictEqual(whatwgEncoding.labelToName("csiso2022jp"), "ISO-2022-JP");
 
-    assert.strictEqual(whatwgEncoding.labelToName("csiso2022kr"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("hz-gb-2312"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("iso-2022-cn"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("iso-2022-cn-ext"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("iso-2022-kr"), null);
+    assert.strictEqual(whatwgEncoding.labelToName("ISO-8859-8-I"), "ISO-8859-8-I");
+    assert.strictEqual(whatwgEncoding.labelToName("csiso88598i"), "ISO-8859-8-I");
+    assert.strictEqual(whatwgEncoding.labelToName("logical"), "ISO-8859-8-I");
 
-    assert.strictEqual(whatwgEncoding.labelToName("x-mac-cyrillic"), null);
-    assert.strictEqual(whatwgEncoding.labelToName("x-mac-ukrainian"), null);
+    assert.strictEqual(whatwgEncoding.labelToName("csiso2022kr"), "replacement");
+    assert.strictEqual(whatwgEncoding.labelToName("hz-gb-2312"), "replacement");
+    assert.strictEqual(whatwgEncoding.labelToName("iso-2022-cn"), "replacement");
+    assert.strictEqual(whatwgEncoding.labelToName("iso-2022-cn-ext"), "replacement");
+    assert.strictEqual(whatwgEncoding.labelToName("iso-2022-kr"), "replacement");
+
+    assert.strictEqual(whatwgEncoding.labelToName("x-mac-cyrillic"), "x-mac-cyrillic");
+    assert.strictEqual(whatwgEncoding.labelToName("x-mac-ukrainian"), "x-mac-cyrillic");
   });
 
   it("should return null for non-strings", () => {
@@ -162,19 +163,16 @@ describe("isSupported", () => {
     assert.strictEqual(whatwgEncoding.isSupported("EUC-KR"), true);
     assert.strictEqual(whatwgEncoding.isSupported("UTF-16BE"), true);
     assert.strictEqual(whatwgEncoding.isSupported("UTF-16LE"), true);
+    assert.strictEqual(whatwgEncoding.isSupported("ISO-2022-JP"), true);
+    assert.strictEqual(whatwgEncoding.isSupported("ISO-8859-8-I"), true);
+    assert.strictEqual(whatwgEncoding.isSupported("replacement"), true);
+    assert.strictEqual(whatwgEncoding.isSupported("x-mac-cyrillic"), true);
   });
 
   it("should return false for miscapitalizations and non-name labels", () => {
     assert.strictEqual(whatwgEncoding.isSupported("utf-8"), false);
     assert.strictEqual(whatwgEncoding.isSupported(" UTF-8"), false);
     assert.strictEqual(whatwgEncoding.isSupported("latin1"), false);
-  });
-
-  it("should return false for the unimplemented encodings", () => {
-    assert.strictEqual(whatwgEncoding.isSupported("ISO-2022-JP"), false);
-    assert.strictEqual(whatwgEncoding.isSupported("ISO-8859-8-I"), false);
-    assert.strictEqual(whatwgEncoding.isSupported("replacement"), false);
-    assert.strictEqual(whatwgEncoding.isSupported("x-mac-cyrillic"), false);
   });
 
   it("should return false for invalid encoding names", () => {


### PR DESCRIPTION
An experiment

Fixes: #22 
Fixes: #23 

* Fixes BOM handling for utf-8
* Fixes replacement support for utf-16
* Fixes utf-8 mistakes on non-Node.js
  (`iconv-lite` Buffer usage maps to https://npmjs.com/buffer which has discrepancies)
* Fixes windows-1252 missing chars (and other legacy single-byte)
* Adds support for all missing encodings
* Closes all other known incompatibilities with the [encoding spec](https://encoding.spec.whatwg.org/)

This is also faster and ~2x smaller than `iconv-lite`.

I kept the API compatible (including label names)

This brings in some differences though which might be a blocker for now or at least a reason for a semver-major:
 * The dependency is ESM. That raises the minimum Node.js version requirement to `^20.19.0 || >=22.13.0` (from 18 currently supported by this module). 18 is EOL per [Node.js release schedule](https://nodejs.org/en/about/previous-releases)
 * This also adds support for `replacement`, as it is expected to be supported in the [hook for standards](https://encoding.spec.whatwg.org/#legacy-hooks).
   Anything using this module to make a `TextDecoder` polyfill could get support for `replacement` _unexpectedly_.
   Users should check that they are not using `replacement` manually.
   An alternative to be specifically block it from being used via this API.

I suggest to wait until an `1.0.0` release before landing (hence a draft), but I wanted to file this as a place to get comments